### PR TITLE
Emit instruction names in JSON

### DIFF
--- a/riscvdecode.ml
+++ b/riscvdecode.ml
@@ -316,11 +316,24 @@ let json_of_operands k =
           String.concat ", " (List.map2 fk opslist typeslist)
     | (_, _) -> ""
 
+let string_of_sizeof_field f =
+  if String.starts_with ~prefix:"0b" f then string_of_int (String.length f - 2)
+  else "0" (* This is a lie. Things like "reg_name" need to be parsed. *)
+
+let json_of_field f =
+  "{ \"field\": \"" ^ f ^ "\", \"size\": " ^ string_of_sizeof_field f ^ " }"
+
+let json_of_fields k =
+  match Hashtbl.find_opt encodings k with
+    None -> ""
+  | Some (fields) -> String.concat ", " (List.map json_of_field fields)
+
 let json_of_instruction k =
   let m = Hashtbl.find assembly k in
     "{\n" ^
     "  \"mnemonic\": " ^ List.hd m ^ ",\n" ^
-    "  \"operands\": [ " ^ (json_of_operands k) ^ " ]\n" ^
+    "  \"operands\": [ " ^ (json_of_operands k) ^ " ],\n" ^
+    "  \"fields\": [ " ^ (json_of_fields k) ^ " ]\n" ^
     "}"
 
 let riscv_decode_info ast env =

--- a/riscvdecode.ml
+++ b/riscvdecode.ml
@@ -328,12 +328,20 @@ let json_of_fields k =
     None -> ""
   | Some (fields) -> String.concat ", " (List.map json_of_field fields)
 
+let json_of_function k =
+  match Hashtbl.find_opt functions k with
+    None -> ""
+  | Some (f) -> String.escaped f
+
 let json_of_instruction k =
   let m = Hashtbl.find assembly k in
     "{\n" ^
     "  \"mnemonic\": " ^ List.hd m ^ ",\n" ^
+    "  \"name\": " ^ "\"TBD\"" ^ ",\n" ^
     "  \"operands\": [ " ^ (json_of_operands k) ^ " ],\n" ^
-    "  \"fields\": [ " ^ (json_of_fields k) ^ " ]\n" ^
+    "  \"fields\": [ " ^ (json_of_fields k) ^ " ],\n" ^
+    "  \"function\": \"" ^ (json_of_function k) ^ "\",\n" ^
+    "  \"description\": " ^ "\"TBD\"" ^ "\n" ^
     "}"
 
 let riscv_decode_info ast env =

--- a/riscvdecode.ml
+++ b/riscvdecode.ml
@@ -300,9 +300,29 @@ let parse_DEF_type def =
   | _ -> print_endline "DEF_type other"
   end
 
+let json_of_operand op = "\"" ^ op ^ "\""
+
+let json_of_key_operand key op t =
+  "\n{\n" ^
+  "  \"name\": \"" ^ op ^ "\"," ^
+  "  \"type\": \"" ^ t ^ "\"\n" ^
+  "}"
+
+let json_of_operands k =
+  let ops = Hashtbl.find_opt operands k
+  and types = Hashtbl.find_opt sigs k in
+    match (ops, types) with
+      (Some opslist, Some typeslist) ->
+        let fk = json_of_key_operand k in
+          String.concat ", " (List.map2 fk opslist typeslist)
+    | (_, _) -> ""
+
 let json_of_instruction k =
   let m = Hashtbl.find assembly k in
-    "{ \"mnemonic\": " ^ List.hd m ^ "}"
+    "{\n" ^
+    "  \"mnemonic\": " ^ List.hd m ^ ",\n" ^
+    "  \"operands\": [ " ^ (json_of_operands k) ^ " ]\n" ^
+    "}"
 
 let riscv_decode_info ast env =
   List.iter (fun def ->

--- a/riscvdecode.ml
+++ b/riscvdecode.ml
@@ -304,8 +304,7 @@ let json_of_operand op = "\"" ^ op ^ "\""
 
 let json_of_key_operand key op t =
   "\n{\n" ^
-  "  \"name\": \"" ^ op ^ "\"," ^
-  "  \"type\": \"" ^ t ^ "\"\n" ^
+  "  \"name\": \"" ^ op ^ "\", \"type\": \"" ^ t ^ "\"\n" ^
   "}"
 
 let json_of_operands k =
@@ -327,6 +326,12 @@ let json_of_instruction k =
 let riscv_decode_info ast env =
   List.iter (fun def ->
     match def with
+      DEF_type ( def ) -> parse_DEF_type def
+    | DEF_spec ( vs ) ->
+        print_endline "DEF_spec";
+        begin match vs with
+          VS_aux ( VS_val_spec (ts, i, eo, b), _) -> print_endline ((string_of_typschm ts) ^ ":" ^ (string_of_id i))
+        end
     | DEF_scattered ( def ) ->
         begin match def with
         | SD_aux ( SD_funcl ( fcl ), _ ) -> parse_SD_funcl fcl
@@ -337,7 +342,6 @@ let riscv_decode_info ast env =
         | SD_aux ( SD_mapcl ( i, mc ), _ ) -> parse_SD_mapcl i mc
         | _ -> print_endline "b"
         end
-    | DEF_type ( def ) -> parse_DEF_type def
     | _ -> print_string ""
   ) ast.defs;
   Hashtbl.iter (fun k v -> print_endline (k ^ ":" ^ v)) types;

--- a/riscvdecode.ml
+++ b/riscvdecode.ml
@@ -25,16 +25,16 @@ let rec parse_mpat x = match x with
   | MP_aux (MP_app ( i, pl ), _) ->
       print_endline ("MP_app " ^ (string_of_id i) ^ " -->");
       List.iter parse_mpat pl;
-      print_endline ("<-- MP_app " ^ (string_of_id i));
+      print_endline ("<-- MP_app " ^ (string_of_id i))
   | MP_aux (MP_vector_concat ( mpl ), _) ->
       print_endline "MP_vector_concat";
-      List.iter parse_mpat mpl;
+      List.iter parse_mpat mpl
   | MP_aux (MP_string_append ( pl ), _) ->
       print_endline "MP_string_append";
       List.iter parse_mpat pl
   | MP_aux (MP_typ ( mp, at ), _) ->
       print_endline "MP_typ";
-      parse_mpat mp;
+      parse_mpat mp
   | _ -> print_endline "mpat other"
 
 let rec string_list_of_mpat x = match x with
@@ -48,30 +48,31 @@ let rec string_list_of_mpat x = match x with
       print_endline ("MP_app " ^ string_of_id i);
       begin match string_of_id i with
       | "spc" | "sep" -> []
-      | _ -> let b = List.concat (List.map string_list_of_mpat pl) in begin
-           print_endline ("<-- MP_app" ^ string_of_id i);
-           List.concat [ [ (string_of_id i); "(" ]; b; [ ")" ] ]
-        end
+      | _ -> let b = List.concat (List.map string_list_of_mpat pl) in
+          begin
+            print_endline ("<-- MP_app" ^ string_of_id i);
+            List.concat [ [ (string_of_id i); "(" ]; b; [ ")" ] ]
+          end
       end
   | MP_aux (MP_vector_concat ( mpl ), _) ->
       print_endline "MP_vector_concat";
-      List.concat (List.map string_list_of_mpat mpl);
+      List.concat (List.map string_list_of_mpat mpl)
   | MP_aux (MP_string_append ( pl ), _) ->
       print_endline "MP_string_append";
       List.concat (List.map string_list_of_mpat pl)
   | MP_aux (MP_typ ( mp, at ), _) ->
       print_endline "MP_typ";
-      string_list_of_mpat mp;
+      string_list_of_mpat mp
   | _ -> assert false
 
 let parse_MPat_aux p = match p with
   | MPat_aux ( MPat_pat (p), _ ) ->
       print_endline ("MPat_pat " ^ string_of_mpat p);
-      parse_mpat p;
+      parse_mpat p
   | MPat_aux ( MPat_when (p, e), _ ) ->
       print_endline ("MPat_when " ^ (string_of_mpat p) ^ " when " ^ (string_of_exp e));
       parse_mpat p;
-      parse_exp e;
+      parse_exp e
   | _ -> print_endline "MCL_bidir other"
 
 let string_lists_of_MPat_aux p = match p with
@@ -91,19 +92,18 @@ let parse_encdec_mpat mp pb = match mp with
         List.iter print_endline operandl;
         Hashtbl.add operands (string_of_id app_id) operandl;
         print_endline "MCL_bidir (right part)";
-        begin match pb with
+        match pb with
         | MPat_aux ( MPat_pat (p), _ ) ->
             print_endline ("MPat_pat ");
             List.iter print_endline (string_list_of_mpat p);
-            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p);
+            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p)
         | MPat_aux ( MPat_when (p, e), _ ) ->
             print_endline ("MPat_when ");
             List.iter print_endline (string_list_of_mpat p);
-            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p);
+            Hashtbl.add encodings (string_of_id app_id) (string_list_of_mpat p)
         | _ ->
             print_endline ("assert ");
             assert false
-        end
       end
   | _ -> assert false
 
@@ -113,14 +113,14 @@ let parse_encdec i mc = match mc with
       begin match pa with
       | MPat_aux ( MPat_pat (p), _ ) ->
           print_endline ("MPat_pat ");
-          parse_encdec_mpat p pb;
+          parse_encdec_mpat p pb
       | MPat_aux ( MPat_when (p, e), _ ) ->
           print_endline ("MPat_when ");
-          parse_encdec_mpat p pb;
+          parse_encdec_mpat p pb
       | _ ->
           print_endline ("assert ");
           assert false
-      end;
+      end
   | _ -> assert false
 
 let add_assembly app_id p = 
@@ -130,7 +130,7 @@ let add_assembly app_id p =
          where the quoted literal mnemonic is in the statement. *)
       if String.get (List.hd x) 0 = '"' then begin
         print_endline ("assembly.add " ^ string_of_id app_id ^ " : " ^ List.hd x);
-        Hashtbl.add assembly (string_of_id app_id) x;
+        Hashtbl.add assembly (string_of_id app_id) x
       end
     end
 
@@ -142,7 +142,7 @@ let parse_assembly_mpat mp pb = match mp with
         List.iter print_endline operandl;
         Hashtbl.add operands (string_of_id app_id) operandl;
         print_endline "MCL_bidir (right part)";
-        begin match pb with
+        match pb with
         | MPat_aux ( MPat_pat (p), _ ) ->
             print_endline ("MPat_pat assembly");
             add_assembly app_id p
@@ -152,7 +152,6 @@ let parse_assembly_mpat mp pb = match mp with
         | _ ->
             print_endline ("assert ");
             assert false
-        end
       end
   | _ -> assert false
 
@@ -174,22 +173,19 @@ let parse_assembly i mc = match mc with
 
 let parse_SD_mapcl i mc =
   print_endline ("SD_mapcl " ^ string_of_id i);
-  if string_of_id i = "encdec" then
-  begin
-    print_endline "ENCDEC!";
-    ignore (parse_encdec i mc);
-  end
-  else if string_of_id i = "assembly" then
-  begin
-    print_endline "ASSEMBLY!";
-    parse_assembly i mc;
-  end;
-  begin match mc with
+  match string_of_id i with
+    "encdec" ->
+      print_endline "ENCDEC!";
+      parse_encdec i mc
+  | "assembly" ->
+      print_endline "ASSEMBLY!";
+      parse_assembly i mc
+  | _ -> ();
+  match mc with
   | MCL_aux ( MCL_bidir ( pa, pb ), _ ) ->
       parse_MPat_aux pa;
       parse_MPat_aux pb
   | _ -> print_endline "mapcl other"
-  end
 
 let parse_execute p e =
   let x = match p with
@@ -207,7 +203,7 @@ let parse_execute p e =
 
 let parse_SD_funcl fcl =
   print_endline "SD_funcl";
-  begin match fcl with
+  match fcl with
   | FCL_aux ( FCL_Funcl ( i, Pat_aux ( j, _ ) ), _ ) ->
       print_endline ("FCL_Funcl " ^ string_of_id i);
       if (string_of_id i) = "execute" then begin
@@ -216,11 +212,11 @@ let parse_SD_funcl fcl =
             print_endline "Pat_exp";
             print_endline (string_of_pat p);
             print_endline "pat -> ";
-            let x = match p with
-                  P_aux ( P_app (x, pl), _ ) ->
-                    print_endline ("P_app " ^ string_of_id x);
-                | _ -> print_endline "pat other"
-              in ();
+            begin match p with
+                P_aux ( P_app (x, pl), _ ) ->
+                  print_endline ("P_app " ^ string_of_id x);
+              | _ -> print_endline "pat other"
+            end;
             print_endline "<- pat";
             print_endline "exp -> ";
             print_endline (string_of_exp e);
@@ -231,15 +227,14 @@ let parse_SD_funcl fcl =
             print_endline (string_of_pat p);
             print_endline (string_of_exp e);
             print_endline (string_of_exp w);
-            parse_execute p e;
+            parse_execute p e
         | _ -> raise (Failure "FCL_Funcl other")
       end
   | _ -> raise (Failure "SD_funcl other")
-  end
 
 let parse_SD_unioncl i ucl =
   print_endline ("SD_unioncl " ^ string_of_id i);
-  begin match ucl with
+  match ucl with
   | Tu_aux ( Tu_ty_id ( c, d ), _ ) ->
       print_string ("Tu_ty_id " ^ string_of_id d ^ "(");
       (* print_endline (string_of_typ c); *)
@@ -251,19 +246,17 @@ let parse_SD_unioncl i ucl =
                 let type_type = try Hashtbl.find types (string_of_typ x0)
                   with Not_found -> "None"
                 in print_string (type_name ^ ":" ^ type_type ^ " ")
-            )
-            x;
+          ) x;
           let l = List.map string_of_typ x in
             Hashtbl.add sigs (string_of_id d) l;
       | _ -> print_endline "Tu_ty_id other"
       end;
       print_endline ")"
   | _ -> print_endline "SD_unioncl other"
-  end
 
 let parse_DEF_type def =
   print_endline "DEF_type";
-  begin match def with
+  match def with
   | TD_aux (TD_abbrev (d, e, f), _) ->
     print_endline ( "TD_abbrev " ^ string_of_id d ^ ":" ^ string_of_typ_arg f);
     Hashtbl.add types (string_of_id d) (string_of_typ_arg f);
@@ -298,7 +291,6 @@ let parse_DEF_type def =
   | TD_aux ( TD_enum (d, e, f), _) -> print_endline ( "TD_enum " ^ string_of_id d )
   | TD_aux ( TD_bitfield (d, e, f), _) -> print_endline ( "TD_bitfield " ^ string_of_id d )
   | _ -> print_endline "DEF_type other"
-  end
 
 let json_of_operand op = "\"" ^ op ^ "\""
 


### PR DESCRIPTION
Clarify extraction of assembly to only extract "simple" assembly where the instruction name is a quoted literal and first in line:
```
mapping clause assembly = RISCV_XPERM4(rs2, rs1, rd)
  <-> "xperm4" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
```

More complex encoding of the assembly representation will come later.

Filter out the tags in "sigs" hashtable that are not also in "assembly" (due to current parsing limitations).

Emit the instructions that are successfully parsed as valid JSON.

Refactored `parse_assembly_mpat` a bit.

Also, added more print/debug, and cleaned up in a few places.